### PR TITLE
Object handler

### DIFF
--- a/lib/xfmr.js
+++ b/lib/xfmr.js
@@ -59,11 +59,14 @@ module.exports = {
    * the form "Controller.handler"
    */
   getRoutePrerequisites (policiesConfig, route) {
-    const handlerTokens = route.handler.split('.')
-    const controller = handlerTokens[0]
-    const handler = handlerTokens[1]
+    let policies
 
-    const policies = _.get(policiesConfig, [ controller, handler ]) || [ ]
+    if (_.isString(route.handler)) {
+      policies = _.get(policiesConfig, route.handler)
+    }
+    else if (_.isPlainObject(route.handler)) {
+      policies = policiesConfig.directories[route.handler.directory.path]
+    }
 
     return {
       config: {

--- a/lib/xfmr.js
+++ b/lib/xfmr.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash')
 const Footprints = require('./footprints')
+const Hoek = require('Hoek')
 const lib = require('./')
 
 module.exports = {
@@ -65,7 +66,13 @@ module.exports = {
       policies = _.get(policiesConfig, route.handler)
     }
     else if (_.isPlainObject(route.handler)) {
-      policies = policiesConfig.directories[route.handler.directory.path]
+      if (route.handler.directory) {
+        policies = policiesConfig.directories[route.handler.directory.path]
+      } else if (route.handler.file) {
+        policies = policiesConfig.files[route.handler.file]
+      } else {
+        Hoek.assert(!route.handler.directory && !route.handler.file, 'policy not recognized')
+      }
     }
 
     return {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Trailpack Router",
   "main": "index.js",
   "dependencies": {
+    "hoek": "^3.0.4",
     "joi": "^7.0.0",
     "lodash": "^3.10.1",
     "trailpack": "latest"


### PR DESCRIPTION
Serving static files now works like this

//config/routes.js

{
  method: "GET",
  path: "/{param*}",
  handler: {
    file: "public/bundle.js"
  }
}

Still working on serving directories.